### PR TITLE
Fixes on CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ find_package(MPI REQUIRED)
 find_package(ABT REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS C)
 
-pkg_check_modules(ABT REQUIRED IMPORTED_TARGET argobots)
-
 include_directories(${MPI_INCLUDE_PATH})
 include_directories(${HDF5_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,21 @@
 cmake_minimum_required(VERSION 3.12)
+
 project(HDF5_VOL_ASYNC VERSION 0.0.1 LANGUAGES C)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
+find_package(MPI REQUIRED)
+find_package(ABT REQUIRED)
+find_package(HDF5 REQUIRED COMPONENTS C)
+
+pkg_check_modules(ABT REQUIRED IMPORTED_TARGET argobots)
+
+include_directories(${MPI_INCLUDE_PATH})
+include_directories(${HDF5_INCLUDE_DIRS})
+
 include(CTest)
 enable_testing()
+
 if(NOT HDF5_VOL_ASYNC_INSTALL_BIN_DIR)
   set(HDF5_VOL_ASYNC_INSTALL_BIN_DIR ${CMAKE_INSTALL_PREFIX}/bin)
 endif()
@@ -18,20 +32,14 @@ if(NOT HDF5_VOL_ASYNC_INSTALL_TEST_DIR)
   set(HDF5_VOL_ASYNC_INSTALL_TEST_DIR ${CMAKE_INSTALL_PREFIX}/test)
 endif()
 
-# install(
-#   DIRECTORY
-#     ${CMAKE_CURRENT_SOURCE_DIR}
-#   DESTINATION
-#     ${HDF5_VOL_ASYNC_INSTALL_TEST_DIR}/test
-# )
-
-
 set(HDF5_VOL_ASYNC_PACKAGE "hdf5_vol_async")
 set(HDF5_VOL_ASYNC_PACKAGE_NAME "HDF5_VOL_ASYNC")
 set(HDF5_VOL_ASYNC_PACKAGE_DESCRIPTION "HDF5 Asynchronous I/O VOL connector")
 set(HDF5_VOL_ASYNC_PACKAGE_URL "https://github.com/hpc-io/vol-async")
 set(HDF5_VOL_ASYNC_PACKAGE_VENDOR "HPC IO")
+
 message(STATUS "Configuring ${HDF5_VOL_ASYNC_PACKAGE} ${PROJECT_VERSION}")
+
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY
       ${PROJECT_BINARY_DIR}/lib CACHE PATH "Single Directory for all libraries."
 )

--- a/cmake/FindABT.cmake
+++ b/cmake/FindABT.cmake
@@ -1,0 +1,24 @@
+find_path(ABT_INCLUDE_DIR
+    NAMES abt.h
+)
+
+find_library(ABT_LIBRARY
+    NAMES abt
+)
+
+set(ABT_INCLUDE_DIRS ${ABT_INCLUDE_DIR})
+set(ABT_LIBRARIES ${ABT_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+    ABT
+    DEFAULT_MSG
+    ABT_LIBRARIES
+    ABT_INCLUDE_DIRS
+)
+
+mark_as_advanced(
+    ABT_LIBRARY
+    ABT_INCLUDE_DIR
+)

--- a/cmake/FindABT.cmake
+++ b/cmake/FindABT.cmake
@@ -1,9 +1,13 @@
 find_path(ABT_INCLUDE_DIR
     NAMES abt.h
+    HINTS $ENV{ABT_DIR}
+    PATH_SUFFIXES include
 )
 
 find_library(ABT_LIBRARY
     NAMES abt
+    HINTS $ENV{ABT_DIR}
+    PATH_SUFFIXES lib
 )
 
 set(ABT_INCLUDE_DIRS ${ABT_INCLUDE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,11 +3,11 @@ set(HDF5_VOL_ASYNC_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_vol.h
 )
 
-add_library(libh5async
+add_library(h5async
     SHARED
     ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_vol.c
 )
-add_library(libasynchdf5
+add_library(asynchdf5
     STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_lib.c
 )
@@ -25,20 +25,20 @@ set(ASYNC_LINK_LIBRARIES
     ${ABT_LIBRARIES}
 )
 
-target_include_directories(libh5async 
+target_include_directories(h5async 
     PRIVATE
     ${ASYNC_INCLUDE_LIBRARIES}
 )
-target_include_directories(libh5async 
+target_include_directories(h5async 
     PRIVATE
     ${ASYNC_INCLUDE_LIBRARIES}
 )
 
-target_link_libraries(libh5async
+target_link_libraries(h5async
     PRIVATE
     ${ASYNC_LINK_LIBRARIES}
 )
-target_link_libraries(libasynchdf5
+target_link_libraries(asynchdf5
     PRIVATE
     ${ASYNC_LINK_LIBRARIES}
 )
@@ -54,8 +54,8 @@ install(
 
 install(
     TARGETS
-        libh5async
-        libasynchdf5
+        h5async
+        asynchdf5
     EXPORT
         ${HDF5_VOL_ASYNC_EXPORTED_TARGETS}
     LIBRARY DESTINATION ${HDF5_VOL_ASYNC_INSTALL_LIB_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,34 +1,63 @@
 set(HDF5_VOL_ASYNC_HEADERS
-  ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_lib.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_vol.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_lib.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_vol.h
 )
 
-set(HDF5_VOL_ASYNC_SRCS
+add_library(libh5async
+    SHARED
     ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_vol.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_lib.c)
-
-add_library(hdf5_vol_async SHARED ${HDF5_VOL_ASYNC_SRCS})
-
-target_include_directories(hdf5_vol_async 
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_library(libasynchdf5
+    STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5_async_lib.c
 )
 
-target_link_libraries(hdf5_vol_async PRIVATE ${LINK_LIBS} abt mpi hdf5)
+set(ASYNC_INCLUDE_LIBRARIES
+    PRIVATE
+    ${ABT_INCLUDE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
-install(
-  FILES
-    ${HDF5_VOL_ASYNC_HEADERS}
-  DESTINATION
-    ${HDF5_VOL_ASYNC_INSTALL_INCLUDE_DIR}
-  COMPONENT
-    headers
+set(ASYNC_LINK_LIBRARIES
+    PRIVATE
+    ${MPI_LIBRARIES}
+    ${HDF5_LIBRARIES}
+    ${ABT_LIBRARIES}
+)
+
+target_include_directories(libh5async 
+    PRIVATE
+    ${ASYNC_INCLUDE_LIBRARIES}
+)
+target_include_directories(libh5async 
+    PRIVATE
+    ${ASYNC_INCLUDE_LIBRARIES}
+)
+
+target_link_libraries(libh5async
+    PRIVATE
+    ${ASYNC_LINK_LIBRARIES}
+)
+target_link_libraries(libasynchdf5
+    PRIVATE
+    ${ASYNC_LINK_LIBRARIES}
 )
 
 install(
-  TARGETS
-    hdf5_vol_async
-  EXPORT
-    ${HDF5_VOL_ASYNC_EXPORTED_TARGETS}
-  LIBRARY DESTINATION ${HDF5_VOL_ASYNC_INSTALL_LIB_DIR}
-  ARCHIVE DESTINATION ${HDF5_VOL_ASYNC_INSTALL_LIB_DIR}
+    FILES
+        ${HDF5_VOL_ASYNC_HEADERS}
+    DESTINATION
+        ${HDF5_VOL_ASYNC_INSTALL_INCLUDE_DIR}
+    COMPONENT
+        headers
+)
+
+install(
+    TARGETS
+        libh5async
+        libasynchdf5
+    EXPORT
+        ${HDF5_VOL_ASYNC_EXPORTED_TARGETS}
+    LIBRARY DESTINATION ${HDF5_VOL_ASYNC_INSTALL_LIB_DIR}
+    ARCHIVE DESTINATION ${HDF5_VOL_ASYNC_INSTALL_LIB_DIR}
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,8 +44,8 @@ foreach(test ${tests} ${tests_p})
         ${MPI_LIBRARIES}
         ${ABT_LIBRARIES}
         ${HDF5_LIBRARIES}
-        libh5async
-        libasynchdf5
+        h5async
+        asynchdf5
     )
     
     # Option 1: If you want to test individually, use the following.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,50 +1,67 @@
 if(DEFINED ENV{HDF5_PLUGIN_PATH})
-  message("HDF5_PLUGIN_PATH is " $ENV{HDF5_PLUGIN_PATH})
+    message("HDF5_PLUGIN_PATH is " $ENV{HDF5_PLUGIN_PATH})
 else()
-  set(ENV{HDF5_PLUGIN_PATH} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-  message("HDF5_PLUGIN_PATH is set to $ENV{HDF5_PLUGIN_PATH}.")
+    set(ENV{HDF5_PLUGIN_PATH} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+    message("HDF5_PLUGIN_PATH is set to $ENV{HDF5_PLUGIN_PATH}.")
 endif()
-if(DEFINED ENV{HDF5_VOL_CONNECTOR})
-   message("HDF5_VOL_CONNECTOR is " $ENV{HDF5_VOL_CONNECTOR})
-else()
-  set(ENV{HDF5_VOL_CONNECTOR} "async under_vol=0;under_info={}")
-  message("HDF5_VOL_CONNECTOR is set to $ENV{HDF5_VOL_CONNECTOR}.")
-endif()
-set(tests
-      async_test_multifile
-      async_test_multifile_env
-      async_test_serial 
-      async_test_serial2
-      async_test_serial_error_stack
-      async_test_serial_event_set
-      async_test_serial_event_set_error_stack)
-find_package(MPI)
-if(MPI_FOUND)
-  message("MPIEXEC is found - ${MPIEXEC}.")
-  set(tests_p
-      async_test_parallel2
-      async_test_parallel3
-      async_test_parallel4
-      async_test_parallel5
-      async_test_parallel)
 
+if(DEFINED ENV{HDF5_VOL_CONNECTOR})
+    message("HDF5_VOL_CONNECTOR is " $ENV{HDF5_VOL_CONNECTOR})
+else()
+    set(ENV{HDF5_VOL_CONNECTOR} "async under_vol=0;under_info={}")
+    message("HDF5_VOL_CONNECTOR is set to $ENV{HDF5_VOL_CONNECTOR}.")
 endif()
-include_directories(SYSTEM ${MPI_INCLUDE_PATH})
+
+set(tests
+    async_test_multifile
+    async_test_multifile_env
+    async_test_serial 
+    async_test_serial2
+    async_test_serial_error_stack
+    async_test_serial_event_set
+    async_test_serial_event_set_error_stack
+)
+
+if(MPI_FOUND)
+    message("MPIEXEC is found - ${MPIEXEC}.")
+    set(tests_p
+        async_test_parallel2
+        async_test_parallel3
+        async_test_parallel4
+        async_test_parallel5
+        async_test_parallel
+    )
+endif()
+
+include_directories(SYSTEM
+    ${MPI_INCLUDE_PATH}
+)
           
 foreach(test ${tests} ${tests_p})
-  add_executable(${test}.exe ${CMAKE_CURRENT_SOURCE_DIR}/${test}.c)
-  target_link_libraries(${test}.exe PRIVATE hdf5_vol_async hdf5 abt ${MPI_C_LIBRARIES})
-  # Option 1: If you want to test individually, use the following.
-  if(${test} MATCHES parallel )
-    add_test(${test} ${MPIEXEC} -np 2 ./${test}.exe) 
-  else()
-    add_test(${test} ${test}.exe)
-  endif()
-  set_tests_properties(
-    ${test}
-    PROPERTIES
-    ENVIRONMENT "HDF5_VOL_CONNECTOR=\"async under_vol=0;under_info={}\";HDF5_PLUGIN_PATH=$ENV{HDF5_PLUGIN_PATH}")
-endforeach ()
+    add_executable(${test}.exe ${CMAKE_CURRENT_SOURCE_DIR}/${test}.c)
+    target_link_libraries(${test}.exe
+        PRIVATE
+        ${MPI_LIBRARIES}
+        ${ABT_LIBRARIES}
+        ${HDF5_LIBRARIES}
+        libh5async
+        libasynchdf5
+    )
+    
+    # Option 1: If you want to test individually, use the following.
+    if(${test} MATCHES parallel)
+        add_test(${test} ${MPIEXEC} -np 2 ./${test}.exe) 
+    else()
+        add_test(${test} ${test}.exe)
+    endif()
+
+    set_tests_properties(
+        ${test}
+        PROPERTIES
+        ENVIRONMENT "HDF5_VOL_CONNECTOR=\"async under_vol=0;under_info={}\";HDF5_PLUGIN_PATH=$ENV{HDF5_PLUGIN_PATH}"
+    )
+endforeach()
+
 # Option2: Test all executables in one Python script.
 # This will not work because pytest.py uses a fixed path.
 # add_test(check_serial ${CMAKE_CURRENT_SOURCE_DIR}/pytest.py)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,16 +14,18 @@ endif()
 
 set(tests
     async_test_multifile
-    async_test_multifile_env
     async_test_serial 
     async_test_serial2
-    async_test_serial_error_stack
     async_test_serial_event_set
     async_test_serial_event_set_error_stack
 )
 
 if(MPI_FOUND)
-    message("MPIEXEC is found - ${MPIEXEC}.")
+    if(NOT DEFINED MPICMD)
+        message("MPIEXEC is found - ${MPIEXEC}.")
+        set(MPICMD ${MPIEXEC})
+    endif()
+
     set(tests_p
         async_test_parallel2
         async_test_parallel3
@@ -47,18 +49,26 @@ foreach(test ${tests} ${tests_p})
         h5async
         asynchdf5
     )
-    
+
     # Option 1: If you want to test individually, use the following.
     if(${test} MATCHES parallel)
-        add_test(${test} ${MPIEXEC} -np 2 ./${test}.exe) 
+        add_test(${test} ${MPICMD} -n 2 ./${test}.exe) 
     else()
         add_test(${test} ${test}.exe)
     endif()
 
-    set_tests_properties(
+    set_property(
+        TEST
         ${test}
-        PROPERTIES
-        ENVIRONMENT "HDF5_VOL_CONNECTOR=\"async under_vol=0;under_info={}\";HDF5_PLUGIN_PATH=$ENV{HDF5_PLUGIN_PATH}"
+        APPEND PROPERTY
+        ENVIRONMENT HDF5_PLUGIN_PATH=$ENV{HDF5_PLUGIN_PATH}
+    )
+
+    set_property(
+        TEST
+        ${test}
+        APPEND PROPERTY 
+        ENVIRONMENT "HDF5_VOL_CONNECTOR=async under_vol=0\;under_info={}"
     )
 endforeach()
 


### PR DESCRIPTION
Implement some fixes on CMakeLists to generate the same library names as the Makefile build. 

I've also included some abstractions to look for the required packages using the CMake concepts rather than forcibly fixing the variables.