### PR TITLE
Allow multiple VOL syntax to Spack

### DIFF
--- a/src/h5_async_vol.c
+++ b/src/h5_async_vol.c
@@ -20508,7 +20508,7 @@ H5VL_async_str_to_info(const char *str, void **_info)
 
     /* Retrieve the underlying VOL connector value and info */
     sscanf(str, "under_vol=%u;", &under_vol_value);
-    under_vol_id         = H5VLregister_connector_by_value((H5VL_class_value_t)under_vol_value, H5P_DEFAULT);
+    under_vol_id = H5VLregister_connector_by_value((H5VL_class_value_t)under_vol_value, H5P_DEFAULT);
     if (strstr(str, "[") && strstr(str, "]")) {
         under_vol_info_start = strchr(str, '[');
         under_vol_info_end   = strrchr(str, ']');

--- a/src/h5_async_vol.c
+++ b/src/h5_async_vol.c
@@ -20509,8 +20509,13 @@ H5VL_async_str_to_info(const char *str, void **_info)
     /* Retrieve the underlying VOL connector value and info */
     sscanf(str, "under_vol=%u;", &under_vol_value);
     under_vol_id         = H5VLregister_connector_by_value((H5VL_class_value_t)under_vol_value, H5P_DEFAULT);
-    under_vol_info_start = strchr(str, '{');
-    under_vol_info_end   = strrchr(str, '}');
+    if (strstr(str, '[') && strstr(str, ']')) {
+        under_vol_info_start = strchr(str, '[');
+        under_vol_info_end   = strrchr(str, ']');
+    } else {
+        under_vol_info_start = strchr(str, '{');
+        under_vol_info_end   = strrchr(str, '}');
+    }
     assert(under_vol_info_end > under_vol_info_start);
     if (under_vol_info_end != (under_vol_info_start + 1)) {
         char *under_vol_info_str;

--- a/src/h5_async_vol.c
+++ b/src/h5_async_vol.c
@@ -20508,11 +20508,12 @@ H5VL_async_str_to_info(const char *str, void **_info)
 
     /* Retrieve the underlying VOL connector value and info */
     sscanf(str, "under_vol=%u;", &under_vol_value);
-    under_vol_id         = H5VLregister_connector_by_value((H5VL_class_value_t)under_vol_value, H5P_DEFAULT);
+    under_vol_id = H5VLregister_connector_by_value((H5VL_class_value_t)under_vol_value, H5P_DEFAULT);
     if (strstr(str, '[') && strstr(str, ']')) {
         under_vol_info_start = strchr(str, '[');
         under_vol_info_end   = strrchr(str, ']');
-    } else {
+    }
+    else {
         under_vol_info_start = strchr(str, '{');
         under_vol_info_end   = strrchr(str, '}');
     }

--- a/src/h5_async_vol.c
+++ b/src/h5_async_vol.c
@@ -20509,7 +20509,7 @@ H5VL_async_str_to_info(const char *str, void **_info)
     /* Retrieve the underlying VOL connector value and info */
     sscanf(str, "under_vol=%u;", &under_vol_value);
     under_vol_id         = H5VLregister_connector_by_value((H5VL_class_value_t)under_vol_value, H5P_DEFAULT);
-    if (strstr(str, '[') && strstr(str, ']')) {
+    if (strstr(str, "[") && strstr(str, "]")) {
         under_vol_info_start = strchr(str, '[');
         under_vol_info_end   = strrchr(str, ']');
     } else {


### PR DESCRIPTION
Allow multiple ways to define the underlying VOL connector `[]` and `{}` to work around the Spack issue with `{}`.